### PR TITLE
Altered tests to fit implementation

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -30,7 +30,6 @@ int main() {
   customerManager.loadCustomers("data4customers.txt");
   CommandProcessor commandProcessor(inventory, customerManager);
   commandProcessor.processCommands("data4commands.txt");
-
 // Check that all movies were loaded
   assert(inventory.findMovie('F', "Sleepless in Seattle 1993") != nullptr);
   assert(inventory.findMovie('F', "Annie Hall 1977") != nullptr);
@@ -124,12 +123,12 @@ int main() {
 
   //TEST TRANSACTION.CPP and CUSTOMER.CPP
   //borrows and returns
-  Borrow borrow1(&customer, &comedyMovie);
-  borrow1.execute();
-  Return return1(&customer, &comedyMovie);
-  return1.execute();
-  Borrow borrow2(&customer, &dramaMovie);
-  borrow2.execute();
+  Borrow* borrow1 = new Borrow(&customer, &comedyMovie);
+  borrow1->execute();
+  Return* return1 = new Return(&customer, &comedyMovie);
+  return1->execute();
+  Borrow* borrow2 = new Borrow(&customer, &dramaMovie);
+  borrow2->execute();
 
   //check history to see if borrows and returns are reflected in history
   customer.displayHistory();

--- a/valgrind-out.txt
+++ b/valgrind-out.txt
@@ -1,191 +1,227 @@
-==3996165== Memcheck, a memory error detector
-==3996165== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
-==3996165== Using Valgrind-3.21.0-d97fed7c3e-20230428 and LibVEX; rerun with -h for copyright info
-==3996165== Command: ./a.out
-==3996165== Parent PID: 3995465
-==3996165== 
---3996165-- 
---3996165-- Valgrind options:
---3996165--    --leak-check=full
---3996165--    --show-leak-kinds=all
---3996165--    --track-origins=yes
---3996165--    --verbose
---3996165--    --log-file=valgrind-out.txt
---3996165-- Contents of /proc/version:
---3996165--   Linux version 4.18.0-513.18.1.el8_9.x86_64 (mockbuild@iad1-prod-build001.bld.equ.rockylinux.org) (gcc version 8.5.0 20210514 (Red Hat 8.5.0-20) (GCC)) #1 SMP Wed Feb 21 21:34:36 UTC 2024
---3996165-- 
---3996165-- Arch and hwcaps: AMD64, LittleEndian, amd64-cx16-lzcnt-rdtscp-sse3-ssse3-avx-avx2-bmi-f16c-rdrand-rdseed
---3996165-- Page sizes: currently 4096, max supported 4096
---3996165-- Valgrind library directory: /usr/libexec/valgrind
---3996165-- Reading syms from /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out
-==3996165== Downloading debug info for /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out...
-==3996165== Server query failed: No such file or directory
---3996165-- Reading syms from /usr/lib64/ld-2.28.so
---3996165-- Warning: cross-CU LIMITATION: some inlined fn names
---3996165-- might be shown as UnknownInlinedFun
---3996165-- Reading syms from /usr/libexec/valgrind/memcheck-amd64-linux
-==3996165== Downloading debug info for /usr/libexec/valgrind/memcheck-amd64-linux...
---3996165--   Considering /home/NETID/mdavid3/.cache/debuginfod_client/23c7103b45550e69e5f2c43318fb819bf3e8f917/debuginfo ..
---3996165--   .. CRC is valid
-==3996165== Successfully downloaded debug file for /usr/libexec/valgrind/memcheck-amd64-linux
-==3996165== Downloading debug info for /home/NETID/mdavid3/.cache/debuginfod_client/23c7103b45550e69e5f2c43318fb819bf3e8f917/debuginfo...
---3996165--   Considering /home/NETID/mdavid3/.cache/debuginfod_client/64b63b4279aacc5afe207ae58fd25605aaefafe8/debuginfo ..
---3996165--   .. build-id is valid
-==3996165== Successfully downloaded debug file for /home/NETID/mdavid3/.cache/debuginfod_client/23c7103b45550e69e5f2c43318fb819bf3e8f917/debuginfo
---3996165--    object doesn't have a dynamic symbol table
---3996165-- Scheduler: using generic scheduler lock implementation.
---3996165-- Reading suppressions file: /usr/libexec/valgrind/default.supp
-==3996165== embedded gdbserver: reading from /tmp/vgdb-pipe-from-vgdb-to-3996165-by-mdavid3-on-csslab8
-==3996165== embedded gdbserver: writing to   /tmp/vgdb-pipe-to-vgdb-from-3996165-by-mdavid3-on-csslab8
-==3996165== embedded gdbserver: shared mem   /tmp/vgdb-pipe-shared-mem-vgdb-3996165-by-mdavid3-on-csslab8
-==3996165== 
-==3996165== TO CONTROL THIS PROCESS USING vgdb (which you probably
-==3996165== don't want to do, unless you know exactly what you're doing,
-==3996165== or are doing some strange experiment):
-==3996165==   /usr/libexec/valgrind/../../bin/vgdb --pid=3996165 ...command...
-==3996165== 
-==3996165== TO DEBUG THIS PROCESS USING GDB: start GDB like this
-==3996165==   /path/to/gdb ./a.out
-==3996165== and then give GDB the following command
-==3996165==   target remote | /usr/libexec/valgrind/../../bin/vgdb --pid=3996165
-==3996165== --pid is optional if only one valgrind process is running
-==3996165== 
---3996165-- REDIR: 0x4005850 (ld-linux-x86-64.so.2:strlen) redirected to 0x580d3692 (vgPlain_amd64_linux_REDIR_FOR_strlen)
---3996165-- REDIR: 0x4005620 (ld-linux-x86-64.so.2:index) redirected to 0x580d36ac (vgPlain_amd64_linux_REDIR_FOR_index)
---3996165-- Reading syms from /usr/libexec/valgrind/vgpreload_core-amd64-linux.so
---3996165-- Reading syms from /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so
-==3996165== WARNING: new redirection conflicts with existing -- ignoring it
---3996165--     old: 0x04005850 (strlen              ) R-> (0000.0) 0x580d3692 vgPlain_amd64_linux_REDIR_FOR_strlen
---3996165--     new: 0x04005850 (strlen              ) R-> (2007.0) 0x04c3e770 strlen
---3996165-- REDIR: 0x4002030 (ld-linux-x86-64.so.2:strcmp) redirected to 0x4c3f930 (strcmp)
---3996165-- REDIR: 0x4005db0 (ld-linux-x86-64.so.2:mempcpy) redirected to 0x4c43460 (mempcpy)
---3996165-- Reading syms from /usr/lib64/libstdc++.so.6.0.25
-==3996165== Downloading debug info for /usr/lib64/libstdc++.so.6.0.25...
---3996165--   Considering /home/NETID/mdavid3/.cache/debuginfod_client/7e2762e395320d20062d39c4ce79f79ae55014a0/debuginfo ..
---3996165--   .. CRC mismatch (computed 3141ed50 wanted 25e7f4c7)
-==3996165== Server Error
---3996165--    object doesn't have a symbol table
---3996165-- Reading syms from /usr/lib64/libm-2.28.so
-==3996165== Downloading debug info for /usr/lib64/libm-2.28.so...
---3996165--   Considering /home/NETID/mdavid3/.cache/debuginfod_client/437b45874ecf965aad19e8f64853ae6b273257eb/debuginfo ..
---3996165--   .. CRC mismatch (computed c8f9a981 wanted 2f754b65)
-==3996165== Server Error
---3996165--    object doesn't have a symbol table
---3996165-- Reading syms from /usr/lib64/libgcc_s-8-20210514.so.1
-==3996165== Downloading debug info for /usr/lib64/libgcc_s-8-20210514.so.1...
---3996165--   Considering /home/NETID/mdavid3/.cache/debuginfod_client/1b8e6ea78d07ffa1765b17a3f537ace57a60a570/debuginfo ..
---3996165--   .. CRC mismatch (computed 8c6cfae8 wanted 7cec3b0b)
-==3996165== Server Error
---3996165--    object doesn't have a symbol table
---3996165-- Reading syms from /usr/lib64/libc-2.28.so
-==3996165== Downloading debug info for /usr/lib64/libc-2.28.so...
-==3996165== Server query failed: No such file or directory
-==3996165== WARNING: new redirection conflicts with existing -- ignoring it
---3996165--     old: 0x058144f0 (memalign            ) R-> (1011.0) 0x04c3d57e memalign
---3996165--     new: 0x058144f0 (memalign            ) R-> (1017.0) 0x04c3da83 aligned_alloc
-==3996165== WARNING: new redirection conflicts with existing -- ignoring it
---3996165--     old: 0x058144f0 (memalign            ) R-> (1011.0) 0x04c3d57e memalign
---3996165--     new: 0x058144f0 (memalign            ) R-> (1017.0) 0x04c3da0d aligned_alloc
-==3996165== WARNING: new redirection conflicts with existing -- ignoring it
---3996165--     old: 0x058144f0 (memalign            ) R-> (1011.0) 0x04c3d57e memalign
---3996165--     new: 0x058144f0 (memalign            ) R-> (1017.0) 0x04c3da83 aligned_alloc
-==3996165== WARNING: new redirection conflicts with existing -- ignoring it
---3996165--     old: 0x058144f0 (memalign            ) R-> (1011.0) 0x04c3d57e memalign
---3996165--     new: 0x058144f0 (memalign            ) R-> (1017.0) 0x04c3da0d aligned_alloc
---3996165-- REDIR: 0x5818770 (libc.so.6:memmove) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
-==3996165== Preferring higher priority redirection:
---3996165--     old: 0x05846e20 (__memcpy_avx_unalign) R-> (2018.0) 0x04c40b70 __memcpy_avx_unaligned_erms
---3996165--     new: 0x05846e20 (__memcpy_avx_unalign) R-> (2018.1) 0x04c424a0 memmove
---3996165-- REDIR: 0x5817a80 (libc.so.6:strncpy) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
---3996165-- REDIR: 0x5818aa0 (libc.so.6:strcasecmp) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
---3996165-- REDIR: 0x5817390 (libc.so.6:strcat) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
---3996165-- REDIR: 0x5817ae0 (libc.so.6:rindex) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
---3996165-- REDIR: 0x581a0d0 (libc.so.6:rawmemchr) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
---3996165-- REDIR: 0x584fd70 (libc.so.6:wmemchr) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
---3996165-- REDIR: 0x584f790 (libc.so.6:wcscmp) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
---3996165-- REDIR: 0x58188d0 (libc.so.6:mempcpy) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
---3996165-- REDIR: 0x5818700 (libc.so.6:bcmp) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
---3996165-- REDIR: 0x5817a10 (libc.so.6:strncmp) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
---3996165-- REDIR: 0x5817440 (libc.so.6:strcmp) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
---3996165-- REDIR: 0x5818840 (libc.so.6:memset) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
---3996165-- REDIR: 0x584f750 (libc.so.6:wcschr) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
---3996165-- REDIR: 0x5817970 (libc.so.6:strnlen) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
---3996165-- REDIR: 0x5817520 (libc.so.6:strcspn) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
---3996165-- REDIR: 0x5818af0 (libc.so.6:strncasecmp) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
---3996165-- REDIR: 0x58174c0 (libc.so.6:strcpy) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
---3996165-- REDIR: 0x5818c40 (libc.so.6:memcpy@@GLIBC_2.14) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
---3996165-- REDIR: 0x5851070 (libc.so.6:wcsnlen) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
---3996165-- REDIR: 0x5817b20 (libc.so.6:strpbrk) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
---3996165-- REDIR: 0x58173f0 (libc.so.6:index) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
---3996165-- REDIR: 0x5817930 (libc.so.6:strlen) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
---3996165-- REDIR: 0x581ebb0 (libc.so.6:memrchr) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
---3996165-- REDIR: 0x5818b40 (libc.so.6:strcasecmp_l) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
---3996165-- REDIR: 0x58186c0 (libc.so.6:memchr) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
---3996165-- REDIR: 0x584f8a0 (libc.so.6:wcslen) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
---3996165-- REDIR: 0x5817de0 (libc.so.6:strspn) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
---3996165-- REDIR: 0x5818a40 (libc.so.6:stpncpy) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
---3996165-- REDIR: 0x58189e0 (libc.so.6:stpcpy) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
---3996165-- REDIR: 0x581a110 (libc.so.6:strchrnul) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
---3996165-- REDIR: 0x5818b90 (libc.so.6:strncasecmp_l) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
---3996165-- REDIR: 0x584fdb0 (libc.so.6:wmemcmp) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
---3996165-- REDIR: 0x5843c40 (libc.so.6:__strrchr_avx2) redirected to 0x4c3e100 (rindex)
---3996165-- REDIR: 0x5813780 (libc.so.6:malloc) redirected to 0x4c3810f (malloc)
---3996165-- REDIR: 0x5843e10 (libc.so.6:__strlen_avx2) redirected to 0x4c3e650 (strlen)
---3996165-- REDIR: 0x5840400 (libc.so.6:__memcmp_avx2_movbe) redirected to 0x4c41b70 (bcmp)
---3996165-- REDIR: 0x583f300 (libc.so.6:__strcmp_avx2) redirected to 0x4c3f7f0 (strcmp)
---3996165-- REDIR: 0x4edfd60 (libstdc++.so.6:operator new(unsigned long)) redirected to 0x4c388a1 (operator new(unsigned long))
---3996165-- REDIR: 0x5846e20 (libc.so.6:__memcpy_avx_unaligned_erms) redirected to 0x4c424a0 (memmove)
---3996165-- REDIR: 0x58182f0 (libc.so.6:__GI_strstr) redirected to 0x4c43640 (__strstr_sse2)
---3996165-- REDIR: 0x4edfe20 (libstdc++.so.6:operator new[](unsigned long)) redirected to 0x4c39bf1 (operator new[](unsigned long))
---3996165-- REDIR: 0x583fc70 (libc.so.6:__memchr_avx2) redirected to 0x4c3f9d0 (memchr)
---3996165-- REDIR: 0x5846e00 (libc.so.6:__mempcpy_avx_unaligned_erms) redirected to 0x4c430a0 (mempcpy)
---3996165-- REDIR: 0x5843a50 (libc.so.6:__strchrnul_avx2) redirected to 0x4c42f90 (strchrnul)
---3996165-- REDIR: 0x4eddd80 (libstdc++.so.6:operator delete(void*)) redirected to 0x4c3b147 (operator delete(void*))
---3996165-- REDIR: 0x4edddb0 (libstdc++.so.6:operator delete[](void*)) redirected to 0x4c3c243 (operator delete[](void*))
---3996165-- REDIR: 0x5813e10 (libc.so.6:free) redirected to 0x4c3abb9 (free)
-==3996165== Conditional jump or move depends on uninitialised value(s)
-==3996165==    at 0x405AF0: CustomHashMap::add(Customer*) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
-==3996165==    by 0x405610: CustomerManager::addCustomer(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
-==3996165==    by 0x4052E4: CustomerManager::loadCustomers(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
-==3996165==    by 0x40C898: main (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
-==3996165==  Uninitialised value was created by a stack allocation
-==3996165==    at 0x40C7E7: main (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
-==3996165== 
-==3996165== Conditional jump or move depends on uninitialised value(s)
-==3996165==    at 0x405AF0: CustomHashMap::add(Customer*) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
-==3996165==    by 0x405610: CustomerManager::addCustomer(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
-==3996165==    by 0x4053BE: CustomerManager::loadCustomers(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
-==3996165==    by 0x40C898: main (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
-==3996165==  Uninitialised value was created by a stack allocation
-==3996165==    at 0x40C7E7: main (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
-==3996165== 
---3996165-- REDIR: 0x4eddd90 (libstdc++.so.6:operator delete(void*, unsigned long)) redirected to 0x4c3b3e3 (operator delete(void*, unsigned long))
-==3996165== 
-==3996165== HEAP SUMMARY:
-==3996165==     in use at exit: 0 bytes in 0 blocks
-==3996165==   total heap usage: 740 allocs, 740 frees, 127,846 bytes allocated
-==3996165== 
-==3996165== All heap blocks were freed -- no leaks are possible
-==3996165== 
-==3996165== ERROR SUMMARY: 12 errors from 2 contexts (suppressed: 0 from 0)
-==3996165== 
-==3996165== 1 errors in context 1 of 2:
-==3996165== Conditional jump or move depends on uninitialised value(s)
-==3996165==    at 0x405AF0: CustomHashMap::add(Customer*) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
-==3996165==    by 0x405610: CustomerManager::addCustomer(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
-==3996165==    by 0x4052E4: CustomerManager::loadCustomers(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
-==3996165==    by 0x40C898: main (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
-==3996165==  Uninitialised value was created by a stack allocation
-==3996165==    at 0x40C7E7: main (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
-==3996165== 
-==3996165== 
-==3996165== 11 errors in context 2 of 2:
-==3996165== Conditional jump or move depends on uninitialised value(s)
-==3996165==    at 0x405AF0: CustomHashMap::add(Customer*) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
-==3996165==    by 0x405610: CustomerManager::addCustomer(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
-==3996165==    by 0x4053BE: CustomerManager::loadCustomers(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
-==3996165==    by 0x40C898: main (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
-==3996165==  Uninitialised value was created by a stack allocation
-==3996165==    at 0x40C7E7: main (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
-==3996165== 
-==3996165== ERROR SUMMARY: 12 errors from 2 contexts (suppressed: 0 from 0)
+==4005170== Memcheck, a memory error detector
+==4005170== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
+==4005170== Using Valgrind-3.21.0-d97fed7c3e-20230428 and LibVEX; rerun with -h for copyright info
+==4005170== Command: ./a.out
+==4005170== Parent PID: 3999786
+==4005170== 
+--4005170-- 
+--4005170-- Valgrind options:
+--4005170--    --leak-check=full
+--4005170--    --show-leak-kinds=all
+--4005170--    --track-origins=yes
+--4005170--    --verbose
+--4005170--    --log-file=valgrind-out.txt
+--4005170-- Contents of /proc/version:
+--4005170--   Linux version 4.18.0-513.18.1.el8_9.x86_64 (mockbuild@iad1-prod-build001.bld.equ.rockylinux.org) (gcc version 8.5.0 20210514 (Red Hat 8.5.0-20) (GCC)) #1 SMP Wed Feb 21 21:34:36 UTC 2024
+--4005170-- 
+--4005170-- Arch and hwcaps: AMD64, LittleEndian, amd64-cx16-lzcnt-rdtscp-sse3-ssse3-avx-avx2-bmi-f16c-rdrand-rdseed
+--4005170-- Page sizes: currently 4096, max supported 4096
+--4005170-- Valgrind library directory: /usr/libexec/valgrind
+--4005170-- Reading syms from /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out
+==4005170== Downloading debug info for /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out...
+==4005170== Server query failed: No such file or directory
+--4005170-- Reading syms from /usr/lib64/ld-2.28.so
+--4005170-- Warning: cross-CU LIMITATION: some inlined fn names
+--4005170-- might be shown as UnknownInlinedFun
+--4005170-- Reading syms from /usr/libexec/valgrind/memcheck-amd64-linux
+==4005170== Downloading debug info for /usr/libexec/valgrind/memcheck-amd64-linux...
+--4005170--   Considering /home/NETID/mdavid3/.cache/debuginfod_client/23c7103b45550e69e5f2c43318fb819bf3e8f917/debuginfo ..
+--4005170--   .. CRC is valid
+==4005170== Successfully downloaded debug file for /usr/libexec/valgrind/memcheck-amd64-linux
+==4005170== Downloading debug info for /home/NETID/mdavid3/.cache/debuginfod_client/23c7103b45550e69e5f2c43318fb819bf3e8f917/debuginfo...
+--4005170--   Considering /home/NETID/mdavid3/.cache/debuginfod_client/64b63b4279aacc5afe207ae58fd25605aaefafe8/debuginfo ..
+--4005170--   .. build-id is valid
+==4005170== Successfully downloaded debug file for /home/NETID/mdavid3/.cache/debuginfod_client/23c7103b45550e69e5f2c43318fb819bf3e8f917/debuginfo
+--4005170--    object doesn't have a dynamic symbol table
+--4005170-- Scheduler: using generic scheduler lock implementation.
+--4005170-- Reading suppressions file: /usr/libexec/valgrind/default.supp
+==4005170== embedded gdbserver: reading from /tmp/vgdb-pipe-from-vgdb-to-4005170-by-mdavid3-on-csslab8
+==4005170== embedded gdbserver: writing to   /tmp/vgdb-pipe-to-vgdb-from-4005170-by-mdavid3-on-csslab8
+==4005170== embedded gdbserver: shared mem   /tmp/vgdb-pipe-shared-mem-vgdb-4005170-by-mdavid3-on-csslab8
+==4005170== 
+==4005170== TO CONTROL THIS PROCESS USING vgdb (which you probably
+==4005170== don't want to do, unless you know exactly what you're doing,
+==4005170== or are doing some strange experiment):
+==4005170==   /usr/libexec/valgrind/../../bin/vgdb --pid=4005170 ...command...
+==4005170== 
+==4005170== TO DEBUG THIS PROCESS USING GDB: start GDB like this
+==4005170==   /path/to/gdb ./a.out
+==4005170== and then give GDB the following command
+==4005170==   target remote | /usr/libexec/valgrind/../../bin/vgdb --pid=4005170
+==4005170== --pid is optional if only one valgrind process is running
+==4005170== 
+--4005170-- REDIR: 0x4005850 (ld-linux-x86-64.so.2:strlen) redirected to 0x580d3692 (vgPlain_amd64_linux_REDIR_FOR_strlen)
+--4005170-- REDIR: 0x4005620 (ld-linux-x86-64.so.2:index) redirected to 0x580d36ac (vgPlain_amd64_linux_REDIR_FOR_index)
+--4005170-- Reading syms from /usr/libexec/valgrind/vgpreload_core-amd64-linux.so
+--4005170-- Reading syms from /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so
+==4005170== WARNING: new redirection conflicts with existing -- ignoring it
+--4005170--     old: 0x04005850 (strlen              ) R-> (0000.0) 0x580d3692 vgPlain_amd64_linux_REDIR_FOR_strlen
+--4005170--     new: 0x04005850 (strlen              ) R-> (2007.0) 0x04c3e770 strlen
+--4005170-- REDIR: 0x4002030 (ld-linux-x86-64.so.2:strcmp) redirected to 0x4c3f930 (strcmp)
+--4005170-- REDIR: 0x4005db0 (ld-linux-x86-64.so.2:mempcpy) redirected to 0x4c43460 (mempcpy)
+--4005170-- Reading syms from /usr/lib64/libstdc++.so.6.0.25
+==4005170== Downloading debug info for /usr/lib64/libstdc++.so.6.0.25...
+--4005170--   Considering /home/NETID/mdavid3/.cache/debuginfod_client/7e2762e395320d20062d39c4ce79f79ae55014a0/debuginfo ..
+--4005170--   .. CRC mismatch (computed 3141ed50 wanted 25e7f4c7)
+==4005170== Server Error
+--4005170--    object doesn't have a symbol table
+--4005170-- Reading syms from /usr/lib64/libm-2.28.so
+==4005170== Downloading debug info for /usr/lib64/libm-2.28.so...
+--4005170--   Considering /home/NETID/mdavid3/.cache/debuginfod_client/437b45874ecf965aad19e8f64853ae6b273257eb/debuginfo ..
+--4005170--   .. CRC mismatch (computed c8f9a981 wanted 2f754b65)
+==4005170== Server Error
+--4005170--    object doesn't have a symbol table
+--4005170-- Reading syms from /usr/lib64/libgcc_s-8-20210514.so.1
+==4005170== Downloading debug info for /usr/lib64/libgcc_s-8-20210514.so.1...
+--4005170--   Considering /home/NETID/mdavid3/.cache/debuginfod_client/1b8e6ea78d07ffa1765b17a3f537ace57a60a570/debuginfo ..
+--4005170--   .. CRC mismatch (computed 8c6cfae8 wanted 7cec3b0b)
+==4005170== Server Error
+--4005170--    object doesn't have a symbol table
+--4005170-- Reading syms from /usr/lib64/libc-2.28.so
+==4005170== Downloading debug info for /usr/lib64/libc-2.28.so...
+==4005170== Server query failed: No such file or directory
+==4005170== WARNING: new redirection conflicts with existing -- ignoring it
+--4005170--     old: 0x058144f0 (memalign            ) R-> (1011.0) 0x04c3d57e memalign
+--4005170--     new: 0x058144f0 (memalign            ) R-> (1017.0) 0x04c3da83 aligned_alloc
+==4005170== WARNING: new redirection conflicts with existing -- ignoring it
+--4005170--     old: 0x058144f0 (memalign            ) R-> (1011.0) 0x04c3d57e memalign
+--4005170--     new: 0x058144f0 (memalign            ) R-> (1017.0) 0x04c3da0d aligned_alloc
+==4005170== WARNING: new redirection conflicts with existing -- ignoring it
+--4005170--     old: 0x058144f0 (memalign            ) R-> (1011.0) 0x04c3d57e memalign
+--4005170--     new: 0x058144f0 (memalign            ) R-> (1017.0) 0x04c3da83 aligned_alloc
+==4005170== WARNING: new redirection conflicts with existing -- ignoring it
+--4005170--     old: 0x058144f0 (memalign            ) R-> (1011.0) 0x04c3d57e memalign
+--4005170--     new: 0x058144f0 (memalign            ) R-> (1017.0) 0x04c3da0d aligned_alloc
+--4005170-- REDIR: 0x5818770 (libc.so.6:memmove) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+==4005170== Preferring higher priority redirection:
+--4005170--     old: 0x05846e20 (__memcpy_avx_unalign) R-> (2018.0) 0x04c40b70 __memcpy_avx_unaligned_erms
+--4005170--     new: 0x05846e20 (__memcpy_avx_unalign) R-> (2018.1) 0x04c424a0 memmove
+--4005170-- REDIR: 0x5817a80 (libc.so.6:strncpy) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+--4005170-- REDIR: 0x5818aa0 (libc.so.6:strcasecmp) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+--4005170-- REDIR: 0x5817390 (libc.so.6:strcat) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+--4005170-- REDIR: 0x5817ae0 (libc.so.6:rindex) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+--4005170-- REDIR: 0x581a0d0 (libc.so.6:rawmemchr) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+--4005170-- REDIR: 0x584fd70 (libc.so.6:wmemchr) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+--4005170-- REDIR: 0x584f790 (libc.so.6:wcscmp) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+--4005170-- REDIR: 0x58188d0 (libc.so.6:mempcpy) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+--4005170-- REDIR: 0x5818700 (libc.so.6:bcmp) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+--4005170-- REDIR: 0x5817a10 (libc.so.6:strncmp) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+--4005170-- REDIR: 0x5817440 (libc.so.6:strcmp) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+--4005170-- REDIR: 0x5818840 (libc.so.6:memset) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+--4005170-- REDIR: 0x584f750 (libc.so.6:wcschr) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+--4005170-- REDIR: 0x5817970 (libc.so.6:strnlen) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+--4005170-- REDIR: 0x5817520 (libc.so.6:strcspn) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+--4005170-- REDIR: 0x5818af0 (libc.so.6:strncasecmp) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+--4005170-- REDIR: 0x58174c0 (libc.so.6:strcpy) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+--4005170-- REDIR: 0x5818c40 (libc.so.6:memcpy@@GLIBC_2.14) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+--4005170-- REDIR: 0x5851070 (libc.so.6:wcsnlen) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+--4005170-- REDIR: 0x5817b20 (libc.so.6:strpbrk) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+--4005170-- REDIR: 0x58173f0 (libc.so.6:index) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+--4005170-- REDIR: 0x5817930 (libc.so.6:strlen) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+--4005170-- REDIR: 0x581ebb0 (libc.so.6:memrchr) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+--4005170-- REDIR: 0x5818b40 (libc.so.6:strcasecmp_l) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+--4005170-- REDIR: 0x58186c0 (libc.so.6:memchr) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+--4005170-- REDIR: 0x584f8a0 (libc.so.6:wcslen) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+--4005170-- REDIR: 0x5817de0 (libc.so.6:strspn) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+--4005170-- REDIR: 0x5818a40 (libc.so.6:stpncpy) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+--4005170-- REDIR: 0x58189e0 (libc.so.6:stpcpy) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+--4005170-- REDIR: 0x581a110 (libc.so.6:strchrnul) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+--4005170-- REDIR: 0x5818b90 (libc.so.6:strncasecmp_l) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+--4005170-- REDIR: 0x584fdb0 (libc.so.6:wmemcmp) redirected to 0x4a3177b (_vgnU_ifunc_wrapper)
+--4005170-- REDIR: 0x5843c40 (libc.so.6:__strrchr_avx2) redirected to 0x4c3e100 (rindex)
+--4005170-- REDIR: 0x5813780 (libc.so.6:malloc) redirected to 0x4c3810f (malloc)
+--4005170-- REDIR: 0x5843e10 (libc.so.6:__strlen_avx2) redirected to 0x4c3e650 (strlen)
+--4005170-- REDIR: 0x5840400 (libc.so.6:__memcmp_avx2_movbe) redirected to 0x4c41b70 (bcmp)
+--4005170-- REDIR: 0x583f300 (libc.so.6:__strcmp_avx2) redirected to 0x4c3f7f0 (strcmp)
+--4005170-- REDIR: 0x4edfd60 (libstdc++.so.6:operator new(unsigned long)) redirected to 0x4c388a1 (operator new(unsigned long))
+--4005170-- REDIR: 0x5846e20 (libc.so.6:__memcpy_avx_unaligned_erms) redirected to 0x4c424a0 (memmove)
+--4005170-- REDIR: 0x58182f0 (libc.so.6:__GI_strstr) redirected to 0x4c43640 (__strstr_sse2)
+--4005170-- REDIR: 0x4edfe20 (libstdc++.so.6:operator new[](unsigned long)) redirected to 0x4c39bf1 (operator new[](unsigned long))
+--4005170-- REDIR: 0x583fc70 (libc.so.6:__memchr_avx2) redirected to 0x4c3f9d0 (memchr)
+--4005170-- REDIR: 0x5846e00 (libc.so.6:__mempcpy_avx_unaligned_erms) redirected to 0x4c430a0 (mempcpy)
+--4005170-- REDIR: 0x5843a50 (libc.so.6:__strchrnul_avx2) redirected to 0x4c42f90 (strchrnul)
+--4005170-- REDIR: 0x4eddd80 (libstdc++.so.6:operator delete(void*)) redirected to 0x4c3b147 (operator delete(void*))
+--4005170-- REDIR: 0x4edddb0 (libstdc++.so.6:operator delete[](void*)) redirected to 0x4c3c243 (operator delete[](void*))
+--4005170-- REDIR: 0x5813e10 (libc.so.6:free) redirected to 0x4c3abb9 (free)
+==4005170== Conditional jump or move depends on uninitialised value(s)
+==4005170==    at 0x405AF8: CustomHashMap::add(Customer*) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170==    by 0x405618: CustomerManager::addCustomer(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170==    by 0x4052EC: CustomerManager::loadCustomers(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170==    by 0x40C8BB: main (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170==  Uninitialised value was created by a stack allocation
+==4005170==    at 0x40C7F5: main (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170== 
+==4005170== Conditional jump or move depends on uninitialised value(s)
+==4005170==    at 0x405AF8: CustomHashMap::add(Customer*) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170==    by 0x405618: CustomerManager::addCustomer(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170==    by 0x4053C6: CustomerManager::loadCustomers(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170==    by 0x40C8BB: main (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170==  Uninitialised value was created by a stack allocation
+==4005170==    at 0x40C7F5: main (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170== 
+--4005170-- REDIR: 0x4eddd90 (libstdc++.so.6:operator delete(void*, unsigned long)) redirected to 0x4c3b3e3 (operator delete(void*, unsigned long))
+==4005170== Conditional jump or move depends on uninitialised value(s)
+==4005170==    at 0x405AF8: CustomHashMap::add(Customer*) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170==    by 0x405618: CustomerManager::addCustomer(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170==    by 0x4052EC: CustomerManager::loadCustomers(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170==    by 0x40EE12: main (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170==  Uninitialised value was created by a stack allocation
+==4005170==    at 0x40C7F5: main (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170== 
+==4005170== Conditional jump or move depends on uninitialised value(s)
+==4005170==    at 0x405AF8: CustomHashMap::add(Customer*) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170==    by 0x405618: CustomerManager::addCustomer(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170==    by 0x4053C6: CustomerManager::loadCustomers(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170==    by 0x40EE12: main (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170==  Uninitialised value was created by a stack allocation
+==4005170==    at 0x40C7F5: main (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170== 
+==4005170== 
+==4005170== HEAP SUMMARY:
+==4005170==     in use at exit: 0 bytes in 0 blocks
+==4005170==   total heap usage: 1,358 allocs, 1,358 frees, 221,949 bytes allocated
+==4005170== 
+==4005170== All heap blocks were freed -- no leaks are possible
+==4005170== 
+==4005170== ERROR SUMMARY: 24 errors from 4 contexts (suppressed: 0 from 0)
+==4005170== 
+==4005170== 1 errors in context 1 of 4:
+==4005170== Conditional jump or move depends on uninitialised value(s)
+==4005170==    at 0x405AF8: CustomHashMap::add(Customer*) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170==    by 0x405618: CustomerManager::addCustomer(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170==    by 0x4052EC: CustomerManager::loadCustomers(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170==    by 0x40EE12: main (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170==  Uninitialised value was created by a stack allocation
+==4005170==    at 0x40C7F5: main (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170== 
+==4005170== 
+==4005170== 1 errors in context 2 of 4:
+==4005170== Conditional jump or move depends on uninitialised value(s)
+==4005170==    at 0x405AF8: CustomHashMap::add(Customer*) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170==    by 0x405618: CustomerManager::addCustomer(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170==    by 0x4052EC: CustomerManager::loadCustomers(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170==    by 0x40C8BB: main (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170==  Uninitialised value was created by a stack allocation
+==4005170==    at 0x40C7F5: main (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170== 
+==4005170== 
+==4005170== 11 errors in context 3 of 4:
+==4005170== Conditional jump or move depends on uninitialised value(s)
+==4005170==    at 0x405AF8: CustomHashMap::add(Customer*) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170==    by 0x405618: CustomerManager::addCustomer(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170==    by 0x4053C6: CustomerManager::loadCustomers(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170==    by 0x40EE12: main (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170==  Uninitialised value was created by a stack allocation
+==4005170==    at 0x40C7F5: main (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170== 
+==4005170== 
+==4005170== 11 errors in context 4 of 4:
+==4005170== Conditional jump or move depends on uninitialised value(s)
+==4005170==    at 0x405AF8: CustomHashMap::add(Customer*) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170==    by 0x405618: CustomerManager::addCustomer(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170==    by 0x4053C6: CustomerManager::loadCustomers(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170==    by 0x40C8BB: main (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170==  Uninitialised value was created by a stack allocation
+==4005170==    at 0x40C7F5: main (in /home/NETID/mdavid3/FredMathewAss4-movie-starter/a.out)
+==4005170== 
+==4005170== ERROR SUMMARY: 24 errors from 4 contexts (suppressed: 0 from 0)


### PR DESCRIPTION

Customer::transactions can hold only "new" allocated memory. This implementation uses new so it needs a destructor, that destructor crashes if it encounters variables not declared this way. If I were to delete the constructor, any transactions declared new would cause memory leaks.